### PR TITLE
:bug: Add `Error` implementation for `std`

### DIFF
--- a/src/hl/error.rs
+++ b/src/hl/error.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use core::fmt::{Display, Formatter};
 
 use embedded_hal::{blocking::spi, digital::v2::OutputPin};
 
@@ -93,6 +94,30 @@ where
     fn from(error: ll::Error<SPI, CS>) -> Self {
         Error::Spi(error)
     }
+}
+
+impl<SPI, CS> Display for Error<SPI, CS>
+where
+    <CS as OutputPin>::Error: fmt::Debug,
+    <SPI as spi::Transfer<u8>>::Error: fmt::Debug,
+    <SPI as spi::Write<u8>>::Error: fmt::Debug,
+    CS: OutputPin,
+    SPI: spi::Transfer<u8> + spi::Write<u8>,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<SPI, CS> std::error::Error for Error<SPI, CS>
+where
+    SPI: spi::Transfer<u8> + spi::Write<u8>,
+    <SPI as spi::Transfer<u8>>::Error: fmt::Debug,
+    <SPI as spi::Write<u8>>::Error: fmt::Debug,
+    CS: OutputPin,
+    <CS as OutputPin>::Error: fmt::Debug,
+{
 }
 
 // We can't derive this implementation, as `Debug` is only implemented

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,8 @@
 //! [register-level interface]: ll/index.html
 //! [`dw1000`]: https://crates.io/crates/dw1000
 //! [`embedded-hal`]: https://crates.io/crates/embedded-hal
-#![cfg_attr(not(test), no_main)]
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(any(test, feature = "std")), no_main)]
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![deny(missing_docs)]
 
 pub mod configs;

--- a/src/ll.rs
+++ b/src/ll.rs
@@ -15,6 +15,7 @@
 //! [high-level interface]: ../hl/index.html
 //! [filing an issue]: https://github.com/braun-robotics/rust-dw3000/issues/new
 
+use core::fmt::{Display, Formatter};
 use core::{fmt, marker::PhantomData};
 
 use embedded_hal::{blocking::spi, digital::v2::OutputPin};
@@ -151,6 +152,30 @@ where
 
     /// Error occured while changing chip select signal
     ChipSelect(<CS as OutputPin>::Error),
+}
+
+impl<SPI, CS> Display for Error<SPI, CS>
+where
+    SPI: spi::Transfer<u8> + spi::Write<u8>,
+    <SPI as spi::Transfer<u8>>::Error: fmt::Debug,
+    <SPI as spi::Write<u8>>::Error: fmt::Debug,
+    CS: OutputPin,
+    <CS as OutputPin>::Error: fmt::Debug,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<SPI, CS> std::error::Error for Error<SPI, CS>
+where
+    SPI: spi::Transfer<u8> + spi::Write<u8>,
+    <SPI as spi::Transfer<u8>>::Error: fmt::Debug,
+    <SPI as spi::Write<u8>>::Error: fmt::Debug,
+    CS: OutputPin,
+    <CS as OutputPin>::Error: fmt::Debug,
+{
 }
 
 // We can't derive this implementation, as the compiler will complain that the


### PR DESCRIPTION
Implements `Error` when Feature std is enabled.
`Display` is just a wrapper for `Debug`.

Is there a reason why `<SPI as spi::Transfer<u8>>::Error: fmt::Debug` is not restricted on `ll::Error` so that `Debug` could be derived? Or is this just to broaden the possible use cases by not limiting it to `Debug`?