### PR TITLE
feat(start_receiving): add parameter recv_time to allow delayed receiving

### DIFF
--- a/src/hl/ready.rs
+++ b/src/hl/ready.rs
@@ -444,7 +444,25 @@ where
     /// and more. Make sure that the values used are the same as of the frames
     /// that are transmitted. The default works with the TxConfig's default and
     /// is a sane starting point.
-    pub fn receive(
+    pub fn receive(self, config: Config) -> Result<DW3000<SPI, SingleBufferReceiving>, Error<SPI>> {
+        self.receive_delayed(ReceiveTime::Now, config)
+    }
+
+    /// Attempt to receive a single IEEE 802.15.4 MAC frame
+    ///
+    /// Initializes the receiver. The method consumes this instance of `DW3000`
+    /// and returns another instance which is in the [SingleBufferReceiving]
+    /// state, and can be used to wait for a message.
+    ///
+    /// This operation can be delayed to aid in distance measurement, by setting
+    /// `recv_time` to `ReceiveTime::Delayed(instant)`. If you want to send the
+    /// frame as soon as possible, just pass `ReceiveTime::Now` instead.
+    ///
+    /// The config parameter allows for the configuration of bitrate, channel
+    /// and more. Make sure that the values used are the same as of the frames
+    /// that are transmitted. The default works with the TxConfig's default and
+    /// is a sane starting point.
+    pub fn receive_delayed(
         self,
         recv_time: ReceiveTime,
         config: Config,

--- a/src/hl/ready.rs
+++ b/src/hl/ready.rs
@@ -40,6 +40,14 @@ pub enum SendTime {
     OnSync,
 }
 
+/// The time at which the reception will start
+pub enum ReceiveTime {
+    /// As fast as possible
+    Now,
+    /// After some time
+    Delayed(Instant),
+}
+
 /// The polarity of the irq signal
 pub enum IrqPolarity {
     /// The signal will be high when the interrupt is active
@@ -436,7 +444,11 @@ where
     /// and more. Make sure that the values used are the same as of the frames
     /// that are transmitted. The default works with the TxConfig's default and
     /// is a sane starting point.
-    pub fn receive(self, config: Config) -> Result<DW3000<SPI, SingleBufferReceiving>, Error<SPI>> {
+    pub fn receive(
+        self,
+        recv_time: ReceiveTime,
+        config: Config,
+    ) -> Result<DW3000<SPI, SingleBufferReceiving>, Error<SPI>> {
         let mut rx_radio = DW3000 {
             ll: self.ll,
             seq: self.seq,
@@ -447,7 +459,7 @@ where
         };
 
         // Start rx'ing
-        rx_radio.start_receiving(config)?;
+        rx_radio.start_receiving(recv_time, config)?;
 
         // Return the double buffer state
         Ok(rx_radio)

--- a/src/hl/receiving.rs
+++ b/src/hl/receiving.rs
@@ -11,7 +11,7 @@ use num_traits::Float;
 #[cfg(feature = "defmt")]
 use defmt::Format;
 
-use super::{AutoDoubleBufferReceiving, Receiving};
+use super::{AutoDoubleBufferReceiving, ReceiveTime, Receiving};
 use crate::{
     configs::{BitRate, PulseRepetitionFrequency, SfdSequence},
     time::Instant,
@@ -68,7 +68,11 @@ where
         Ok(self.ll.sys_state().read()?.rx_state())
     }
 
-    pub(super) fn start_receiving(&mut self, config: Config) -> Result<(), Error<SPI>> {
+    pub(super) fn start_receiving(
+        &mut self,
+        recv_time: ReceiveTime,
+        config: Config,
+    ) -> Result<(), Error<SPI>> {
         if config.frame_filtering {
             self.ll.sys_cfg().modify(
                 |_, w| w.ffen(0b1), // enable frame filtering
@@ -85,7 +89,26 @@ where
             self.ll.sys_cfg().modify(|_, w| w.ffen(0b0))?; // disable frame filtering
         }
 
-        self.fast_cmd(FastCommand::CMD_RX)?;
+        match recv_time {
+            ReceiveTime::Delayed(time) => {
+                // Panic if the time is not rounded to top 31 bits
+                //
+                // NOTE: DW3000's DX_TIME register is 32 bits wide, but only the top 31 bits are used.
+                // The last bit is ignored per the user manual!!!
+                if time.value() % (1 << 9) != 0 {
+                    panic!("Time must be rounded to top 31 bits!");
+                }
+
+                // Put the time into the delay register
+                // By setting this register, the chip knows to delay before transmitting
+                self.ll
+                    .dx_time()
+                    .modify(|_, w| // 32-bits value of the most significant bits
+                    w.value( (time.value() >> 8) as u32 ))?;
+                self.fast_cmd(FastCommand::CMD_DRX)?;
+            }
+            ReceiveTime::Now => self.fast_cmd(FastCommand::CMD_RX)?,
+        }
 
         Ok(())
     }


### PR DESCRIPTION
This is a fix for the PR #6 of @elrafoon. It adds the required changes to the function signature(s) to get this merged:

- Renames `receive` to `receive_delayed`
- Adds a thin wrapper around `receive_delayed` called `receive`, having the original signature and therefore not breaking the API