### PR TITLE
Simplify frame filtering usage

### DIFF
--- a/src/configs.rs
+++ b/src/configs.rs
@@ -17,7 +17,7 @@ pub struct Config {
     pub preamble_length: PreambleLength,
     /// Sets the bitrate of the transmission.
     pub bitrate: BitRate,
-    /// Defaults to `true`.
+    /// Defaults to `false`.
     pub frame_filtering: bool,
     /// Sets the ranging bit in the transmitted frame.
     /// This has no effect on the capabilities of the DW3000.

--- a/src/hl/ready.rs
+++ b/src/hl/ready.rs
@@ -367,7 +367,7 @@ where
     #[inline(always)]
     #[maybe_async_attr]
     pub async fn send(
-        mut self,
+        self,
         data: &[u8],
         send_time: SendTime,
         config: Config,
@@ -375,8 +375,8 @@ where
         return self.send_to(
             data,
             send_time,
-            Some(Ieee802154Address::BROADCAST),
-            None,
+            Ieee802154Pan::BROADCAST,
+            Ieee802154Address::BROADCAST,
             config,
         ).await;
     }

--- a/src/hl/ready.rs
+++ b/src/hl/ready.rs
@@ -335,10 +335,7 @@ where
     where
         T: AsRef<[u8]>,
     {
-        let mut buffer = [0_u8; 127];
-        buffer[0..].copy_from_slice(frame.into_inner().as_ref());
-
-        self.send_raw(&buffer, send_time, config).await
+        self.send_raw(frame.into_inner().as_ref(), send_time, config).await
     }
 
     /// Send an IEEE 802.15.4 MAC frame

--- a/src/hl/ready.rs
+++ b/src/hl/ready.rs
@@ -180,10 +180,10 @@ where
             frame_pending: false,
             ack_request: false,
             pan_id_compression: true,
-            dst_addr: dst_addr,
+            dst_addr,
             src_addr: Some(src_addr),
             src_pan_id: Some(src_pan_id),
-            dst_pan_id: dst_pan_id,
+            dst_pan_id,
         }
     } 
     
@@ -350,7 +350,7 @@ where
         let mut buffer= [0_u8; 127];
         buffer[0..].copy_from_slice(frame.into_inner().as_ref());
         
-        self.send_raw(&mut buffer, send_time, config).await
+        self.send_raw(&buffer, send_time, config).await
     }
 
 

--- a/src/hl/ready.rs
+++ b/src/hl/ready.rs
@@ -294,7 +294,7 @@ where
                 if time.value() % (1 << 9) != 0 {
                     panic!("Time must be rounded to top 31 bits!");
                 }
-                
+
                 // Put the time into the delay register
                 // By setting this register, the chip knows to delay before transmitting
                 self.ll

--- a/src/hl/ready.rs
+++ b/src/hl/ready.rs
@@ -201,15 +201,16 @@ where
         let mut frame = Ieee802154Frame::new_unchecked(&mut buffer[0..]);
         frame_header.emit(&mut frame);
 
+        let len = frame_header.buffer_len() + data.len();
+
         // copy data
-        buffer[frame_header.buffer_len()..frame_header.buffer_len() + data.len()]
+        buffer[frame_header.buffer_len()..len]
             .copy_from_slice(data);
 
         // footer
-        buffer[frame_header.buffer_len() + data.len()] = 0x00;
-
-        (frame_header.buffer_len() + data.len()) as usize
+        buffer[len] = 0x00;
         
+        len
     }
     
 
@@ -417,7 +418,7 @@ where
             Some(pan_id)
         ).await;
 
-        return self.send_raw(&buffer[0..len], send_time, config).await;
+        return self.send_raw(&buffer[0..len + 2], send_time, config).await;
     }
 
     /// Attempt to receive a single IEEE 802.15.4 MAC frame

--- a/src/hl/ready.rs
+++ b/src/hl/ready.rs
@@ -122,6 +122,29 @@ where
         Ok(())
     }
 
+    /// clear evernt counter evc_ctrl->evc_clr
+    pub async fn clear_event_counter(&mut self) {
+        self.ll
+            .evc_ctrl()
+            .write(|w| w.evc_clr(0b1))
+            .await.expect("Failed to set evc_ctrl->evc_clr");
+    }
+
+    /// enable_event_counter evc_ctrl->evc_en
+    pub async fn enable_event_counter(&mut self) {
+        self.ll
+            .evc_ctrl()
+            .write(|w| w.evc_en(0b1))
+            .await.expect("Failed to set evc_ctrl->evc_en");
+    }
+    
+    /// enable_tx_clock clk_ctrl->tx_clk
+    pub async fn enable_tx_clock(&mut self){
+        self.ll
+            .clk_ctrl()
+            .write(|w| w.tx_clk(0b10))
+            .await.expect("Failed to set clk_ctrl->tx_clk");
+    }
     /// Send an raw UWB PHY frame
     ///
     /// The `data` argument is wrapped into an raw UWB PHY frame.

--- a/src/hl/ready.rs
+++ b/src/hl/ready.rs
@@ -287,6 +287,7 @@ where
 
         match send_time {
             SendTime::Delayed(time) => {
+                // Panic if the time is not rounded to top 31 bits
                 //
                 // NOTE: DW3000's DX_TIME register is 32 bits wide, but only the top 31 bits are used.
                 // The last bit is ignored per the user manual!!!

--- a/src/hl/ready.rs
+++ b/src/hl/ready.rs
@@ -122,7 +122,8 @@ where
         Ok(())
     }
 
-    /// clear evernt counter evc_ctrl->evc_clr
+    /// clear event counter evc_ctrl->evc_clr
+    #[maybe_async_attr]
     pub async fn clear_event_counter(&mut self) {
         self.ll
             .evc_ctrl()
@@ -130,7 +131,8 @@ where
             .await.expect("Failed to set evc_ctrl->evc_clr");
     }
 
-    /// enable_event_counter evc_ctrl->evc_en
+    /// re-enable event counter evc_ctrl->evc_en
+    #[maybe_async_attr]
     pub async fn enable_event_counter(&mut self) {
         self.ll
             .evc_ctrl()
@@ -139,6 +141,7 @@ where
     }
     
     /// enable_tx_clock clk_ctrl->tx_clk
+    #[maybe_async_attr]
     pub async fn enable_tx_clock(&mut self){
         self.ll
             .clk_ctrl()
@@ -146,15 +149,13 @@ where
             .await.expect("Failed to set clk_ctrl->tx_clk");
     }
 
-
-
-
     /// Creates a IEEE 802.15.4 MAC frame header
     /// With destination address and pan id targets
     /// For a broadcast frame use:
     ///    dst_addr: Some(Ieee802154Address::BROADCAST),
     ///    dst_pan_id: None
     /// NOTE: every call will increment the frame sequence code
+    #[maybe_async_attr]
     pub async fn build_frame_header(
         &mut self, 
         dst_addr: Option<Ieee802154Address>,
@@ -187,6 +188,7 @@ where
     /// The `data` argument is populated on the payload
     /// 
     /// It returns the length of the message (Header + Data)
+    #[maybe_async_attr]
     pub async fn build_frame(
         &mut self, 
         buffer: &mut [u8],

--- a/src/hl/ready.rs
+++ b/src/hl/ready.rs
@@ -335,7 +335,8 @@ where
     where
         T: AsRef<[u8]>,
     {
-        self.send_raw(frame.into_inner().as_ref(), send_time, config).await
+        self.send_raw(frame.into_inner().as_ref(), send_time, config)
+            .await
     }
 
     /// Send an IEEE 802.15.4 MAC frame


### PR DESCRIPTION
This PR aims to simplify the creation of targeted messages to support *Frame Filtering* and prevent additional logic after the receive cycle to discard messages. 


The new workflow consists of having a helper method to build the IEEE 802.15.4 MAC frames without having to import the whole chain from `smoltcp` and to make sure all the messages created and sent follow the same pattern across, also unifies the workflow, reducing the code duplication that was occurring before between the send actions shaving some computing cycles and improving the maintenance.

```mermaid
flowchart LR
    A[send] --> B[send_to] --> C[send_raw]
    D[send_frame] --> C[send_raw]
    C[send_raw] --> U1[
        1 resets
        2 populates buffer
        3 apply settings
        4 set delays
        5 returns the sending instance
    ]
```

Additions:

- `send_to()`: method to permit target frames 
- `clear_event_counter()`: helper method to clear event counter (evc_ctrl->evc_clr)
- `enable_event_counter()`:  helper method to re-enable the event counter (evc_ctrl->evc_en)
- `enable_tx_clock()`: helper to enable tx clock (clk_ctrl->tx_clk)
- `build_frame_header()`: method to aid the creation of IEEE 802.15.4 MAC frame header with the given targets
- `build_frame()`: method to populate formated IEEE 802.15.4 MAC frame buffers including the data payload


Note: During my tests, replacing some of the `modify` with `write` decreased the execution cycles, sometimes by 1/3 of the original time to send the same payload(I am using a microsecond timestamp log on an esp32 and basic diff math to get these numbers). I understand that we might need to read some data in some instances, but I haven't found any reason to leave the param available. Let me know if you know a reason to keep the other original.


