### PR TITLE
Make `serde` optional but enabled by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,14 +41,16 @@ tokio = { version = "1", features = ["full"] }
 version = "1"
 default-features = false
 features = ["derive"]
+optional = true
 
 [dependencies.num_enum]
 version = "0.7"
 default-features = false
 
 [features]
-default = ["async", "rssi"]
-std = ["serde/std", "num_enum/std"]
+default = ["async", "rssi", "serde"]
+std = ["serde?/std", "num_enum/std"]
 async = []
 defmt = ["dep:defmt"]
 rssi = ["dep:num-traits"]
+serde = ["dep:serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,13 +43,9 @@ default-features = false
 features = ["derive"]
 optional = true
 
-[dependencies.num_enum]
-version = "0.7"
-default-features = false
-
 [features]
 default = ["async", "rssi", "serde"]
-std = ["serde?/std", "num_enum/std"]
+std = ["serde?/std"]
 async = []
 defmt = ["dep:defmt"]
 rssi = ["dep:num-traits"]

--- a/src/hl/receiving.rs
+++ b/src/hl/receiving.rs
@@ -38,8 +38,9 @@ pub struct Message<'l> {
 }
 
 /// A struct representing the quality of the received message.
+#[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(Format))]
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RxQuality {
     /// The confidence that there was Line Of Sight between the sender and the
     /// receiver.

--- a/src/time.rs
+++ b/src/time.rs
@@ -2,7 +2,6 @@
 
 use core::ops::{Add, Sub};
 
-
 #[cfg(feature = "defmt")]
 use defmt::Format;
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -2,7 +2,6 @@
 
 use core::ops::{Add, Sub};
 
-use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "defmt")]
 use defmt::Format;
@@ -17,8 +16,9 @@ pub const TIME_MAX: u64 = 0xffffffffff;
 /// Internally uses the same 40-bit timestamps that the DW3000 uses.
 ///
 /// [`DW3000::sys_time`]: ../hl/struct.DW3000.html#method.sys_time
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "defmt", derive(Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]
 pub struct Instant(u64);
 
@@ -154,7 +154,8 @@ impl Sub<Instant> for Instant {
 /// A duration between two instants in DW3000 system time
 ///
 /// Internally uses the same 40-bit timestamps that the DW3000 uses.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]
 pub struct Duration(u64);
 


### PR DESCRIPTION
This PR makes the `serde` dependency optional. The "serde" feature is enabled by default for compatibility (although that still doesn't make this change 100% backwards compatible since users might rely on serde with `default-features=false`).
Personally, I would remove "serde" from the default features as well.

It also looks like the `num_enum` dependency is completely unused so I removed it as well.