### PR TITLE
Make indirect usage of defmt through smoltcp optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ embedded-hal = "1.0"
 embedded-hal-async = "1.0"
 smoltcp = { version = ">=0.11", default-features = false, features = [
     "socket-raw",
-    "defmt",
     "medium-ieee802154",
 ] }
 nb = "1.0"
@@ -47,6 +46,6 @@ optional = true
 default = ["async", "rssi", "serde"]
 std = ["serde?/std"]
 async = []
-defmt = ["dep:defmt"]
+defmt = ["dep:defmt", "smoltcp/defmt"]
 rssi = ["dep:num-traits"]
 serde = ["dep:serde"]

--- a/src/hl/uninitialized.rs
+++ b/src/hl/uninitialized.rs
@@ -74,7 +74,7 @@ where
         let ldo_tune_h = self.read_otp(0x05).await?;
 
         // Read BIASTUNE_CAL value from OTP memory (bit 16 to 20)
-        let biastune_cal = self.read_otp(0x0A).await? >> 0x10 & 0x1F;
+        let biastune_cal = (self.read_otp(0x0A).await? >> 0x10) & 0x1F;
 
         #[cfg(feature = "defmt")]
         defmt::trace!(


### PR DESCRIPTION
This made `defmt` a transitive dependency even without the `defmt` feature being enabled.