### PR TITLE
[FIX] 'warning: hiding a lifetime that's elided elsewhere is confusing'

### DIFF
--- a/src/ll.rs
+++ b/src/ll.rs
@@ -567,7 +567,7 @@ macro_rules! impl_register {
         impl<SPI> DW3000<SPI> {
             $(
                 #[$doc]
-                pub fn $name_lower(&mut self) -> RegAccessor<$name, SPI> {
+                pub fn $name_lower(&mut self) -> RegAccessor<'_, $name, SPI> {
                     RegAccessor(self, PhantomData)
                 }
             )*
@@ -1679,7 +1679,7 @@ impl Writable for TX_BUFFER {
 
 impl<SPI> DW3000<SPI> {
     /// Transmit Data Buffer
-    pub fn tx_buffer(&mut self) -> RegAccessor<TX_BUFFER, SPI> {
+    pub fn tx_buffer(&mut self) -> RegAccessor<'_, TX_BUFFER, SPI> {
         RegAccessor(self, PhantomData)
     }
 }
@@ -1728,7 +1728,7 @@ impl Readable for RX_BUFFER_0 {
 
 impl<SPI> DW3000<SPI> {
     /// Receive Data Buffer
-    pub fn rx_buffer_0(&mut self) -> RegAccessor<RX_BUFFER_0, SPI> {
+    pub fn rx_buffer_0(&mut self) -> RegAccessor<'_, RX_BUFFER_0, SPI> {
         RegAccessor(self, PhantomData)
     }
 }
@@ -1789,7 +1789,7 @@ impl Readable for RX_BUFFER_1 {
 
 impl<SPI> DW3000<SPI> {
     /// Receive Data Buffer1
-    pub fn rx_buffer_1(&mut self) -> RegAccessor<RX_BUFFER_1, SPI> {
+    pub fn rx_buffer_1(&mut self) -> RegAccessor<'_, RX_BUFFER_1, SPI> {
         RegAccessor(self, PhantomData)
     }
 }


### PR DESCRIPTION
This commits fixes various warnings on Rust 1.89 because of elided lifetimes:
```rust
warning: hiding a lifetime that's elided elsewhere is confusing
    --> src/ll.rs:570:36
     |
570  |                   pub fn $name_lower(&mut self) -> RegAccessor<$name, SPI> {
     |                                      ^^^^^^^^^     ----------------------- the same lifetime is hidden here     |                                      |
     |                                      the lifetime is elided here
...
633  | / impl_register! {
634  | |
635  | |     0x00, 0x00, 4, RO, DEV_ID(dev_id) { /// Device identifier
636  | |         rev,     0,  3, u8;  /// Revision
...    |
1653 | | }
     | |_- in this macro invocation
     |
     = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
     = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
     = note: this warning originates in the macro `impl_register` (in Nightly builds, run with -Z macro-backtrace for more info)
help: use `'_` for type paths
     |
570  |                 pub fn $name_lower(&mut self) -> RegAccessor<'_, $name, SPI> {
     |                                                              +++

warning: hiding a lifetime that's elided elsewhere is confusing
    --> src/ll.rs:1682:22
     |
1682 |     pub fn tx_buffer(&mut self) -> RegAccessor<TX_BUFFER, SPI> {
     |                      ^^^^^^^^^     --------------------------- the same lifetime is hidden here
     |                      |
     |                      the lifetime is elided here
     |
     = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
     |
1682 |     pub fn tx_buffer(&mut self) -> RegAccessor<'_, TX_BUFFER, SPI> {
     |                                                +++

warning: hiding a lifetime that's elided elsewhere is confusing
    --> src/ll.rs:1731:24
     |
1731 |     pub fn rx_buffer_0(&mut self) -> RegAccessor<RX_BUFFER_0, SPI> {
     |                        ^^^^^^^^^     ----------------------------- the same lifetime is hidden here
     |                        |
     |                        the lifetime is elided here
     |
     = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
     |
1731 |     pub fn rx_buffer_0(&mut self) -> RegAccessor<'_, RX_BUFFER_0, SPI> {
     |                                                  +++

warning: hiding a lifetime that's elided elsewhere is confusing
    --> src/ll.rs:1792:24
     |
1792 |     pub fn rx_buffer_1(&mut self) -> RegAccessor<RX_BUFFER_1, SPI> {
     |                        ^^^^^^^^^     ----------------------------- the same lifetime is hidden here
     |                        |
     |                        the lifetime is elided here
     |
     = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
     |
1792 |     pub fn rx_buffer_1(&mut self) -> RegAccessor<'_, RX_BUFFER_1, SPI> {
     |                                                  +++

warning: `dw3000-ng` (lib) generated 4 warnings
```